### PR TITLE
Feat: Add ttyd to display a readonly terminal on the web with the fedserver python output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN if [ "$jlab" = true ]; then \
     else echo "[INFO] Skip JupyterLab installation!"; fi
 
 # Install user app
-RUN git clone --depth 1 -b $branch https://github.com/deephdc/federated-server && \
+RUN git clone --depth 1 -b main https://github.com/deephdc/federated-server && \
     cd  federated-server && \
     pip3 install --no-cache-dir -e . && \
     cd ..

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN git clone --depth 1 https://github.com/deephdc/deep-start /srv/.deep-start &
 
 # Install JupyterLab
 ENV JUPYTER_CONFIG_DIR /srv/.deep-start/
-ENV FEDERATED_ROUNDS 2
+
 # Necessary for the Jupyter Lab terminal
 ENV SHELL /bin/bash
 RUN if [ "$jlab" = true ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN if [ "$jlab" = true ]; then \
     else echo "[INFO] Skip JupyterLab installation!"; fi
 
 # Install user app
-RUN git clone --depth 1 -b main https://github.com/deephdc/federated-server && \
+RUN git clone --depth 1 -b $branch https://github.com/deephdc/federated-server && \
     cd  federated-server && \
     pip3 install --no-cache-dir -e . && \
     cd ..


### PR DESCRIPTION
- Use [https://github.com/tsl0922/ttyd](ttyd) in readonly mode to enable the display of a terminal on the web (monitor endpoint) so that the user can check the status of the fedserver online.